### PR TITLE
e2ls: Expect inode numbers to be as long as 10 characters at maximum

### DIFF
--- a/e2tool-e2ls.c
+++ b/e2tool-e2ls.c
@@ -738,7 +738,7 @@ void long_disp(ls_file_t *info, int UNUSED_PARM(*col), int options)
     }
 
 
-  printf("%c%6u%c %10s %s %s  ", lbr, info->inode_num, rbr,
+  printf("%c%10u%c %10s %s %s  ", lbr, info->inode_num, rbr,
          modestr, userstr, groupstr);
   if (LINUX_S_ISDIR(info->inode.i_mode))
     printf("%7d", info->inode.i_size);


### PR DESCRIPTION
Currently, unpleasant to be looked at outputs such as this one can be produced
when '-l' is being used on disks with more than 1,000,000 inodes:
```
     12  lrwxrwxrwx     root     root        7 13-Nov-2019 17:23 bin
 7864321  drwxr-xr-x     root     root     4096  3-Oct-2019 22:06 boot
 1572865  drwxr-xr-x     root     root     4096  3-Oct-2019 22:06 dev
 6291457  drwxr-xr-x     root     root     4096 11-Feb-2020 19:00 etc
 4063233  drwxr-xr-x     root     root     4096  4-Oct-2019 19:55 home
     13  lrwxrwxrwx     root     root        7 13-Nov-2019 17:23 lib
     14  lrwxrwxrwx     root     root        7 13-Nov-2019 17:23 lib64
     11  drwx------     root     root    16384  3-Oct-2019 22:05 lost+found
```
As this is a quite common case on modern systems, it causes an actual aesthetics
problem ;]
Setting the format string's minimum field width to 10 plays nicely with the
32-bit (unsigned) inode number limit of ext{2,3,4} itself - namely 4,294,967,295.