### PR TITLE
e2tail: Ensure that the last BLK_SIZE bytes of a file are read

### DIFF
--- a/src/e2tool-e2tail.c
+++ b/src/e2tool-e2tail.c
@@ -315,8 +315,9 @@ tail(ext2_filsys *fs_ptr, ext2_ino_t root, char *input, int num_lines,
       ptr = buf + bytes_read - 1;
       while (bytes_to_read--)
         {
-          if (*ptr == '\n' && num_lines-- == 0)
+          if (*ptr == '\n' && num_lines == 0)
             {
+              num_lines--;
               /* if the newline wasn't the last character in the buffer, then
                * print what's remaining.
                */
@@ -335,10 +336,14 @@ tail(ext2_filsys *fs_ptr, ext2_ino_t root, char *input, int num_lines,
           ptr--;
         }
 
+      /* if we have read from the top of the file, break out of this loop */
+      if (offset == 0)
+        break;
+
       offset -= (offset < BLK_SIZE) ? offset : BLK_SIZE;
       bytes_to_read = BLK_SIZE;
     }
-  while (offset > 0);
+  while (1);
 
   /* if we are here and have any lines left, we hit the beginning, so
    * dump the rest of what's in memory out.


### PR DESCRIPTION
When a file is `size > BLK_SIZE`, e2tail will parse the last `size % BLK_SIZE` bytes first, then every other iteration should be of size `BLK_SIZE` until the top of the file. However, the last `BLK_SIZE` that should be read seems to be getting skipped. This is due to the [loop termination condition](https://github.com/e2tools/e2tools/blob/master/src/e2tool-e2tail.c#L338-L341
), where `offset -= (offset < BLK_SIZE) ? offset : BLK_SIZE; `will result in `offset = 0`, and `while (offset > 0);` will no longer be true.

Additionally in this case, when num_lines is exactly equal to the file length, [the post-decrement here](https://github.com/e2tools/e2tools/blob/master/src/e2tool-e2tail.c#L318) will cause [this block](https://github.com/e2tools/e2tools/blob/master/src/e2tool-e2tail.c#L347-L353) to not execute, losing the top-most lines.

See Issue #24.