### PR TITLE
e2cp: support copy of symbolic links with new -l flag

### DIFF
--- a/src/e2cp.1
+++ b/src/e2cp.1
@@ -29,6 +29,9 @@ the host filesystem.
 .B \-G \fIgid\fP
 Set the default group to gid.
 .TP
+.B \-l
+Copy symbolic links without following.
+.TP
 .B \-O \fIuid\fP
 Set the default file owner to uid.
 .TP
@@ -55,6 +58,12 @@ Copy a file and use the default permission and ownership of the current user:
 Do the same thing, but keep permissions & ownership:
 
     e2cp \-p README.txt /tmp/boot.img:/tmp
+.\"
+.PP
+Copy a symbolic link without following:
+
+    ln -s README.md README.md.link
+    e2cp \-l README.md.link /tmp/boot.img:/tmp
 .\"
 .PP
 Dump a file to standard out:

--- a/src/write.h
+++ b/src/write.h
@@ -4,6 +4,6 @@
 extern
 long
 put_file(ext2_filsys fs, ext2_ino_t cwd, char *infile, char *outfile,
-         ext2_ino_t *outfile_ino, int keep, struct stat *def_stat);
+         ext2_ino_t *outfile_ino, int keep, int is_link, struct stat *def_stat);
 
 #endif /* !defined(E2TOOLS_WRITE_H) */


### PR DESCRIPTION
This proposal introduces the `-l` flag to e2cp, which preserves symbolic links (not follow) and copy them as is.
This option is particularly useful for building filesystem images, which contains symbolic links to files that are only generated on runtime.