### PR TITLE
Disable portability warning as error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([
 -Wall
 -Werror
+-Wno-portability
 1.9.6
 foreign
 subdir-objects


### PR DESCRIPTION
With latest automake 1.17 its warning about escape hash mark [1] and since configure.ac uses -werror to call automake this becomes an error and reconfigure fails.

escape hash mark is non-portable as discussed here [2]

Fow now let it be a warning, it should be fixed in a portable way

[1] https://debbugs.gnu.org/cgi/bugreport.cgi?bug=7610
[2] https://lists.gnu.org/archive/html/automake/2011-08/msg00023.html