### PR TITLE
build: disable automake treating warnings as error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,6 @@ AC_CONFIG_SRCDIR([src/e2tools.c])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([
 -Wall
--Werror
 -Wno-portability
 1.9.6
 foreign


### PR DESCRIPTION
fixes #32