### PR TITLE
Return an error code if the file isn't found in read.c

### DIFF
--- a/src/read.c
+++ b/src/read.c
@@ -120,7 +120,7 @@ get_file(ext2_filsys fs, ext2_ino_t root, ext2_ino_t cwd,
               unlink(outfile);
 #endif
             }
-          return(0);
+          return(-1);
         }
       fputs(error_message(retval), stderr);
       return retval;


### PR DESCRIPTION
When using e2cp in bash scripts, we'd like an error response back if the file we're trying to copy doesn't exist (& as a result, wasn't copied successfully).